### PR TITLE
WDP-3 Add margin on above the header for devices wider than 758px

### DIFF
--- a/src/layout/Nav.jsx
+++ b/src/layout/Nav.jsx
@@ -14,9 +14,9 @@ function Navigation() {
 
     return (
         <div className="nav container">
-            <Link to="/" className="nav__logo">
+            <a href="#home" className="nav__logo">
                 DMawi
-            </Link>
+            </a>
             {toggleOn && (
                 <div className="nav__menu" id="nav_menu">
                     <ul className="nav__list grid" onClick={handleToggle}>

--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -75,18 +75,22 @@
         color: $clr-primary;
         transition: 0.3s;
     }
+
     &-button:hover {
         transform: translateY(0.25rem);
     }
+
     &-mouse {
         font-size: 2rem;
     }
+
     &-name {
         font-size: $fs-sm;
         color: $clr-title;
         font-weight: $fw-reg;
-        margin-right: $mb-025;
+        margin: 0 $mb-025 0;
     }
+
     &-arrow {
         font-size: 1.25rem;
     }

--- a/src/sass/media-queries/_medium.scss
+++ b/src/sass/media-queries/_medium.scss
@@ -47,7 +47,7 @@
     }
 
     .section {
-        padding: 6rem 0 2rem;
+        padding: 7.5rem 0 2rem;
 
         &__subtitle {
             margin-bottom: 4rem;


### PR DESCRIPTION
Gap was added b/n the text and the icon in scroll down button. This task was from WDP-4. Also the logo is now link to direct to home.